### PR TITLE
Fixed for preview values and 12_0_0_pre1

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1057,7 +1057,6 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 <hr size="2" noshade>
 <br>
 
-
         <li><strong>CMSSW_11_2_0_pre2</strong>
         <br>
 	<ul>
@@ -1095,10 +1094,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre2%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre2%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre2_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre2_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1132,7 +1131,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre2%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre2%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1156,10 +1155,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre3_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 95.4596 s/ev ==> 105.654 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre3_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 105.654 s/ev ==> 95.4596 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre3_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 22469810 ==> 23037102 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre3_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 23037102 ==> 22469810 </span>
 				</li>
 			</ul>
 		
@@ -1174,10 +1173,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre3_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre3_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1193,10 +1192,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre3_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 2.99719 s/ev ==> 3.10688 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre3_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.10688 s/ev ==> 2.99719 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre3_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 241042 ==> 243068 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre3_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 243068 ==> 241042 </span>
 				</li>
 			</ul>
 		
@@ -1211,7 +1210,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1234,10 +1233,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre4_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 96.0085 s/ev ==> 95.4596 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre4_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 95.4596 s/ev ==> 96.0085 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre4_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 22983725 ==> 22469810 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre4_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 22469810 ==> 22983725 </span>
 				</li>
 			</ul>
 		
@@ -1252,10 +1251,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre4_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre4_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1271,10 +1270,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre4_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.15094 s/ev ==> 2.99719 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre4_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 2.99719 s/ev ==> 3.15094 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre4_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 243223 ==> 241042 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre4_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 241042 ==> 243223 </span>
 				</li>
 			</ul>
 		
@@ -1289,7 +1288,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1312,10 +1311,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre5_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 95.8911 s/ev ==> 96.0085 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre5_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 96.0085 s/ev ==> 95.8911 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre5_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 22982747 ==> 22983725 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre5_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 22983725 ==> 22982747 </span>
 				</li>
 			</ul>
 		
@@ -1330,10 +1329,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre5_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre5_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1349,10 +1348,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre5_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.12189 s/ev ==> 3.15094 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre5_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.15094 s/ev ==> 3.12189 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre5_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 243222 ==> 243223 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre5_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 243223 ==> 243222 </span>
 				</li>
 			</ul>
 		
@@ -1367,7 +1366,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1390,10 +1389,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre6_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 92.516 s/ev ==> 95.8911 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre6_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 95.8911 s/ev ==> 92.516 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre6_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 22948333 ==> 22982747 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre6_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 22982747 ==> 22948333 </span>
 				</li>
 			</ul>
 		
@@ -1408,10 +1407,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre6_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre6_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1427,10 +1426,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre6_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.16688 s/ev ==> 3.12189 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre6_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.12189 s/ev ==> 3.16688 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre6_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 244183 ==> 243222 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre6_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 243222 ==> 244183 </span>
 				</li>
 			</ul>
 		
@@ -1445,7 +1444,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1468,10 +1467,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre7_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 102.923 s/ev ==> 92.516 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre7_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 92.516 s/ev ==> 102.923 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre7_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 26732049 ==> 22948333 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre7_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 22948333 ==> 26732049 </span>
 				</li>
 			</ul>
 		
@@ -1486,10 +1485,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre7_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre7_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1505,10 +1504,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre7_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 5.22438 s/ev ==> 3.16688 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre7_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.16688 s/ev ==> 5.22438 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre7_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 600886 ==> 244183 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre7_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 244183 ==> 600886 </span>
 				</li>
 			</ul>
 		
@@ -1523,7 +1522,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1546,10 +1545,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre8_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 100.66 s/ev ==> 102.923 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre8_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 102.923 s/ev ==> 100.66 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre8_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 26198473 ==> 26732049 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre8_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 26732049 ==> 26198473 </span>
 				</li>
 			</ul>
 		
@@ -1564,10 +1563,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre8_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre8_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1583,10 +1582,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre8_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 5.18759 s/ev ==> 5.22438 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre8_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 5.22438 s/ev ==> 5.18759 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre8_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 582193 ==> 600886 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre8_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 600886 ==> 582193 </span>
 				</li>
 			</ul>
 		
@@ -1601,7 +1600,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1624,10 +1623,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre9_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 83.4152 s/ev ==> 100.66 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre9_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 100.66 s/ev ==> 83.4152 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre9_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19131312 ==> 26198473 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre9_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 26198473 ==> 19131312 </span>
 				</li>
 			</ul>
 		
@@ -1642,10 +1641,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre9_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre9_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1661,10 +1660,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre9_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.68892 s/ev ==> 5.18759 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre9_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 5.18759 s/ev ==> 3.68892 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre9_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 258662 ==> 582193 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre9_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 582193 ==> 258662 </span>
 				</li>
 			</ul>
 		
@@ -1679,7 +1678,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1702,10 +1701,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre10_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 81.9172 s/ev ==> 83.4152 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre10_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 83.4152 s/ev ==> 81.9172 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre10_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19336587 ==> 19131312 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre10_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19131312 ==> 19336587 </span>
 				</li>
 			</ul>
 		
@@ -1720,10 +1719,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre10_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre10_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1739,10 +1738,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre10_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.64704 s/ev ==> 3.68892 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre10_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.68892 s/ev ==> 3.64704 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre10_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 260678 ==> 258662 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre10_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 258662 ==> 260678 </span>
 				</li>
 			</ul>
 		
@@ -1757,7 +1756,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1780,10 +1779,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre11_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 83.1855 s/ev ==> 81.9172 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre11_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 81.9172 s/ev ==> 83.1855 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre11_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19539653 ==> 19336587 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre11_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19336587 ==> 19539653 </span>
 				</li>
 			</ul>
 		
@@ -1798,10 +1797,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre11_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre11_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1817,10 +1816,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre11_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.55582 s/ev ==> 3.64704 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_pre11_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.64704 s/ev ==> 3.55582 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre11_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 259944 ==> 260678 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_pre11_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 260678 ==> 259944 </span>
 				</li>
 			</ul>
 		
@@ -1835,7 +1834,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1858,10 +1857,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 83.608 s/ev ==> 83.1855 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 83.1855 s/ev ==> 83.608 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19543703 ==> 19539653 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19539653 ==> 19543703 </span>
 				</li>
 			</ul>
 		
@@ -1876,10 +1875,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1895,10 +1894,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.59772 s/ev ==> 3.55582 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_0_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.55582 s/ev ==> 3.59772 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 260024 ==> 259944 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_0_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 259944 ==> 260024 </span>
 				</li>
 			</ul>
 		
@@ -1913,7 +1912,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1936,10 +1935,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_1_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 84.857 s/ev ==> 83.608 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_1_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 83.608 s/ev ==> 84.857 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_1_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19541575 ==> 19543703 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_1_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19543703 ==> 19541575 </span>
 				</li>
 			</ul>
 		
@@ -1954,10 +1953,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_1_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_1_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -1973,10 +1972,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_1_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.56349 s/ev ==> 3.59772 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_2_1_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.59772 s/ev ==> 3.56349 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_1_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 260258 ==> 260024 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_2_1_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 260024 ==> 260258 </span>
 				</li>
 			</ul>
 		
@@ -1991,9 +1990,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
+
 
         <hr size="3" noshade>
         <h2>CMSSW_11_3_X <font size="4em"></font></h2>
@@ -2004,7 +2004,6 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 </span>
 <hr size="2" noshade>
 <br>
-
 
         <li><strong>CMSSW_11_3_0_pre1</strong>
         <br>
@@ -2025,10 +2024,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre1_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 84.8088 s/ev ==> 84.857 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre1_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 84.857 s/ev ==> 84.8088 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre1_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19539963 ==> 19541575 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre1_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19541575 ==> 19539963 </span>
 				</li>
 			</ul>
 		
@@ -2043,10 +2042,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre1_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre1_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -2062,10 +2061,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre1_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.56143 s/ev ==> 3.56349 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre1_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.56349 s/ev ==> 3.56143 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre1_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 262110 ==> 260258 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre1_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 260258 ==> 262110 </span>
 				</li>
 			</ul>
 		
@@ -2080,7 +2079,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2103,10 +2102,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre2_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 81.5136 s/ev ==> 84.8088 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre2_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 84.8088 s/ev ==> 81.5136 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre2_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 18906425 ==> 19539963 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre2_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19539963 ==> 18906425 </span>
 				</li>
 			</ul>
 		
@@ -2121,10 +2120,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre2_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre2_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -2140,10 +2139,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre2_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.4286 s/ev ==> 3.56143 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre2_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.56143 s/ev ==> 3.4286 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre2_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 257293 ==> 262110 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre2_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 262110 ==> 257293 </span>
 				</li>
 			</ul>
 		
@@ -2158,7 +2157,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2181,10 +2180,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre3_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 84.0407 s/ev ==> 81.5136 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre3_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 81.5136 s/ev ==> 84.0407 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre3_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19140614 ==> 18906425 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre3_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 18906425 ==> 19140614 </span>
 				</li>
 			</ul>
 		
@@ -2199,10 +2198,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre3_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre3_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -2218,10 +2217,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre3_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.96139 s/ev ==> 3.4286 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre3_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.4286 s/ev ==> 3.96139 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre3_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 266247 ==> 257293 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre3_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 257293 ==> 266247 </span>
 				</li>
 			</ul>
 		
@@ -2236,7 +2235,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2259,10 +2258,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre4_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 84.618 s/ev ==> 84.0407 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre4_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 84.0407 s/ev ==> 84.618 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre4_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19105924 ==> 19140614 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre4_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19140614 ==> 19105924 </span>
 				</li>
 			</ul>
 		
@@ -2277,10 +2276,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre4_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre4_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -2296,10 +2295,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre4_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.83468 s/ev ==> 3.96139 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre4_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.96139 s/ev ==> 3.83468 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre4_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 264397 ==> 266247 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre4_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 266247 ==> 264397 </span>
 				</li>
 			</ul>
 		
@@ -2314,7 +2313,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2337,10 +2336,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre5_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 86.1739 s/ev ==> 84.618 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre5_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 84.618 s/ev ==> 86.1739 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre5_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19503754 ==> 19105924 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre5_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19105924 ==> 19503754 </span>
 				</li>
 			</ul>
 		
@@ -2355,10 +2354,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre5_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -2374,10 +2373,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre5_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.97042 s/ev ==> 3.83468 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre5_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.83468 s/ev ==> 3.97042 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre5_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 264867 ==> 264397 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre5_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 264397 ==> 264867 </span>
 				</li>
 			</ul>
 		
@@ -2392,7 +2391,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2415,10 +2414,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre6_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 83.653 s/ev ==> 86.1739 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre6_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 86.1739 s/ev ==> 83.653 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre6_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19277306 ==> 19503754 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre6_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19503754 ==> 19276586 </span>
 				</li>
 			</ul>
 		
@@ -2433,10 +2432,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre6_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -2452,10 +2451,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre6_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.88974 s/ev ==> 3.97042 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_11_3_0_pre6_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.97042 s/ev ==> 3.88974 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre6_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 269744 ==> 264867 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_11_3_0_pre6_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 264867 ==> 269746 </span>
 				</li>
 			</ul>
 		
@@ -2470,7 +2469,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2483,7 +2482,6 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 </span>
 <hr size="2" noshade>
 <br>
-
 
 
         <li><strong>CMSSW_12_0_0_pre1</strong>
@@ -2505,10 +2503,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_12_0_0_pre1_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 78.0377 s/ev ==> 83.653 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_12_0_0_pre1_step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 83.653 s/ev ==> 78.0377 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_12_0_0_pre1_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 17742858 ==> 19276586 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_12_0_0_pre1_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 19276586 ==> 17742858 </span>
 				</li>
 			</ul>
 		
@@ -2523,10 +2521,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
-		<li><strong>step4_AOD(RECO):</strong>
+		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre1_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
 		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1_step4_cpu.res" title="txtLink">[txtLink]</a>
@@ -2542,10 +2540,10 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		
 			<ul type='disc'>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_12_0_0_pre1_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.75051 s/ev ==> 3.88974 s/ev </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_12_0_0_pre1_step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 3.88974 s/ev ==> 3.75051 s/ev </span>
 				</li>
 				<li>
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_12_0_0_pre1_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 268196 ==> 269746 </span>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_12_0_0_pre1_step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 269746 ==> 268196 </span>
 				</li>
 			</ul>
 		
@@ -2560,8 +2558,6 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
-
-


### PR DESCRIPTION
Modified part
- TimeDiff etc arrows pointed from old to new
- igprof results links to `txtLink` are linked correct page.
- The link about step4 piecharts is pointed to packages. ( `groups=packages` ) 

The `Short Summary Time and Memory` page is being modified now.

This pull request has no problem merging with the previous webpage. ( The problem with the `Short Summary Time and Memory` are just to correct the linked HTML file. )