### PR TITLE
Remove igprof for CMSSW_12_0_0_pre4

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2834,6 +2834,6 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</ul>
 		
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>

--- a/web/index.html
+++ b/web/index.html
@@ -2801,14 +2801,6 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 	<ul>
 		<li><strong>step3_AOD(RECO):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre4_step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre4/23434.21/step3/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
-		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre4_step3_cpu.res" title="txtLink">[txtLink]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre4/23434.21/step3/mem_live.1" title="MEM check">[Memory Profiler igprof.1]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre4_step3_mem1.res">[txtLink]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre4/23434.21/step3/mem_live.50" title="MEM check">[Memory Profiler igprof.50]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre4_step3_mem50.res">[txtLink]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre4/23434.21/step3/mem_live.99" title="MEM check">[Memory Profiler igprof.99]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre4_step3_mem99.res">[txtLink]</a>
 		<ul>
 
 			<li>Comparison:
@@ -2821,16 +2813,6 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_12_0_0_pre4_step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 12579345 ==> 8191280 </span>
 				</li>
 			</ul>
-		
-			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/CMSSW_12_0_0_pre4_step3_cpu_endjob.html" title="CPU compare">[CPU compare]</a>
-			</li>
-			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/CMSSW_12_0_0_pre4_step3_mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
-			</li>
-			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/CMSSW_12_0_0_pre4_step3_mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
-			</li>
 	
 			<li>Circle (Pie chart):
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
@@ -2838,14 +2820,6 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
 		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre4_step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre4/23434.21/step4/cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
-		<a target='_blank' href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre4_step4_cpu.res" title="txtLink">[txtLink]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre4/23434.21/step4/mem_live.1" title="MEM check">[Memory Profiler igprof.1]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre4_step4_mem1.res">[txtLink]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre4/23434.21/step4/mem_live.50" title="MEM check">[Memory Profiler igprof.50]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre4_step4_mem50.res">[txtLink]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre4/23434.21/step4/mem_live.99" title="MEM check">[Memory Profiler igprof.99]</a>
-		<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre4_step4_mem99.res">[txtLink]</a>
 		<ul>
 
 			<li>Comparison:
@@ -2859,16 +2833,6 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 				</li>
 			</ul>
 		
-			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/CMSSW_12_0_0_pre4_step4_cpu_endjob.html" title="CPU compare">[CPU compare]</a>
-			</li>
-			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/CMSSW_12_0_0_pre4_step4_mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
-			</li>
-			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/CMSSW_12_0_0_pre4_step4_mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
-			</li>
-	
 			<li>Circle (Pie chart):
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>

--- a/web/index.html
+++ b/web/index.html
@@ -1173,7 +1173,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1210,7 +1210,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1251,7 +1251,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1288,7 +1288,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1329,7 +1329,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1366,7 +1366,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1407,7 +1407,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1444,7 +1444,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1485,7 +1485,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1522,7 +1522,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1563,7 +1563,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1600,7 +1600,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1641,7 +1641,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1678,7 +1678,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1719,7 +1719,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1756,7 +1756,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1797,7 +1797,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1834,7 +1834,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1875,7 +1875,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1912,7 +1912,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -1953,7 +1953,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -1990,7 +1990,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2042,7 +2042,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -2079,7 +2079,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2120,7 +2120,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -2157,7 +2157,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2198,7 +2198,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -2235,7 +2235,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2276,7 +2276,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -2313,7 +2313,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2354,7 +2354,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -2391,7 +2391,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2432,7 +2432,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -2469,7 +2469,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2510,7 +2510,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -2547,7 +2547,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2599,7 +2599,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -2636,7 +2636,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2677,7 +2677,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -2714,7 +2714,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2755,7 +2755,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>
@@ -2792,7 +2792,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</li>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul></ul>
 
@@ -2815,7 +2815,7 @@ CMSSW_11_2_0_pre2 Test for D41 cs D49
 			</ul>
 	
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=packages&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 		<li><strong>step4_MiniAOD(PAT):</strong>


### PR DESCRIPTION
Since igprof was broken in 12_0_0_pre4 (https://github.com/jpata/cms-reco-profiling-web/issues/17), let's remove the links to the missing igprof data for this release

cc @xoqhdgh1002 @slava77