### PR TITLE
Fixes to the webpage, add 12_1_0_pre4

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -275,7 +275,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -318,7 +318,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -366,7 +366,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -409,7 +409,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -457,7 +457,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -500,7 +500,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -548,7 +548,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -588,7 +588,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -633,7 +633,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -676,7 +676,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -724,7 +724,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -767,7 +767,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -815,7 +815,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -858,7 +858,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -906,7 +906,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -949,7 +949,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -997,7 +997,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -1040,7 +1040,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1088,7 +1088,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -1131,7 +1131,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1179,7 +1179,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -1222,7 +1222,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1288,7 +1288,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -1331,7 +1331,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1379,7 +1379,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -1422,7 +1422,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1470,7 +1470,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -1513,7 +1513,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1561,7 +1561,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -1604,7 +1604,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1697,7 +1697,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -1740,7 +1740,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1788,7 +1788,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -1831,7 +1831,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1879,7 +1879,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -1922,7 +1922,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1970,7 +1970,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -2049,7 +2049,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -2155,7 +2155,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -2234,7 +2234,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -2313,7 +2313,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -2356,7 +2356,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2404,7 +2404,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -2447,7 +2447,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2495,7 +2495,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -2538,7 +2538,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2586,7 +2586,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -2629,7 +2629,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2730,7 +2730,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -2762,7 +2762,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2810,7 +2810,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -2853,7 +2853,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2968,7 +2968,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -3011,7 +3011,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3059,7 +3059,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -3102,7 +3102,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3150,7 +3150,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -3193,7 +3193,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3241,7 +3241,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -3284,7 +3284,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3350,7 +3350,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -3393,7 +3393,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3441,7 +3441,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -3484,7 +3484,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3532,7 +3532,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -3575,7 +3575,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3623,7 +3623,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -3666,7 +3666,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3714,7 +3714,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -3757,7 +3757,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3805,7 +3805,7 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
@@ -3848,7 +3848,189 @@
 			</li>
 			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			</li>
+		</ul>
+</ul>
+
+	        <li><strong>CMSSW_12_1_0_pre4(11834.21)</strong>
+	        <br>
+		<ul>
+
+			<li><strong>step3_AOD(RECO):</strong>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
+			
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
+				<ul>
+			<li>Comparison:
+		
+			<ul type='disc'>
+				<li>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 15.6321 s/ev ==> 16.3093 s/ev </span>
+				</li>
+				<li>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 614467 ==> 627189 </span>
+				</li>
+			</ul>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
+			</li>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
+			</li>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
+			</li>
+			
+			<li>Circle (Pie chart):
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre4%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			</li>
+		</ul>
+
+			<li><strong>step4_MiniAOD(PAT):</strong>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
+			
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
+				<ul>
+			<li>Comparison:
+		
+			<ul type='disc'>
+				<li>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 0.620509 s/ev ==> 0.634289 s/ev </span>
+				</li>
+				<li>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/11834.21/step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 108899 ==> 110750 </span>
+				</li>
+			</ul>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/11834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
+			</li>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/11834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
+			</li>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/11834.21/step4/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
+			</li>
+			
+			<li>Circle (Pie chart):
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre4%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			</li>
+		</ul>
+</ul>
+
+	        <li><strong>CMSSW_12_1_0_pre4(34834.21)</strong>
+	        <br>
+		<ul>
+
+			<li><strong>step3_AOD(RECO):</strong>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
+			
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/34834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/34834.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/34834.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
+				<ul>
+			<li>Comparison:
+		
+			<ul type='disc'>
+				<li>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step3.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 60.1329 s/ev ==> 61.9771 s/ev </span>
+				</li>
+				<li>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step3.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 6495574 ==> 6443668 </span>
+				</li>
+			</ul>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/34834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
+			</li>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/34834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
+			</li>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/34834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			</li>
+			
+			<li>Circle (Pie chart):
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre4%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			</li>
+		</ul>
+
+			<li><strong>step4_MiniAOD(PAT):</strong>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
+			
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/34834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/34834.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
+				
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre4/34834.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
+				<ul>
+			<li>Comparison:
+		
+			<ul type='disc'>
+				<li>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/TimeDiff/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step4.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;">preview: 4.47367 s/ev ==> 4.36865 s/ev </span>
+				</li>
+				<li>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/CompProd/CMSSW_12_1_0_pre4/slc7_amd64_gcc900/34834.21/step4.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;">preview: 273020 ==> 271009 </span>
+				</li>
+			</ul>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/34834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
+			</li>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/34834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
+			</li>
+			
+			<li>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre4/34834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			</li>
+			
+			<li>Circle (Pie chart):
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre4%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>

--- a/web/index.html
+++ b/web/index.html
@@ -118,16 +118,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_1_0/slc7_amd64_gcc820/20634.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_1_0/slc7_amd64_gcc820/20634.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_1_0/slc7_amd64_gcc820/20634.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step3//mem_live.25" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step3//mem_live.25" title="MEM time check">[MEM Profiler igprof.25]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_1_0/slc7_amd64_gcc820/20634.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step3//mem_live.49" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step3//mem_live.49" title="MEM time check">[MEM Profiler igprof.49]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_1_0/slc7_amd64_gcc820/20634.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -149,16 +149,16 @@
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_1_0/slc7_amd64_gcc820/20634.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_1_0/slc7_amd64_gcc820/20634.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_1_0/slc7_amd64_gcc820/20634.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step4//mem_live.25" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step4//mem_live.25" title="MEM time check">[MEM Profiler igprof.25]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_1_0/slc7_amd64_gcc820/20634.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step4//mem_live.49" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_1_0/20634.21/step4//mem_live.49" title="MEM time check">[MEM Profiler igprof.49]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_1_0/slc7_amd64_gcc820/20634.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -194,16 +194,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre2/slc7_amd64_gcc820/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre2/slc7_amd64_gcc820/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre2/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre2/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre2/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Circle (Pie chart):
@@ -214,16 +214,16 @@
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre2/slc7_amd64_gcc820/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre2/slc7_amd64_gcc820/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre2/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre2/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre2/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre2/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Circle (Pie chart):
@@ -239,16 +239,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre3/slc7_amd64_gcc820/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre3/slc7_amd64_gcc820/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre3/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre3/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre3/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -265,31 +265,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre3/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre3/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre3/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre3/slc7_amd64_gcc820/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre3/slc7_amd64_gcc820/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre3/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre3/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre3/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre3/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -306,15 +308,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre3/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre3/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre3/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre3%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -326,16 +330,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre4/slc7_amd64_gcc820/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre4/slc7_amd64_gcc820/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre4/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre4/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre4/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -352,31 +356,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre4/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre4/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre4/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre4/slc7_amd64_gcc820/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre4/slc7_amd64_gcc820/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre4/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre4/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre4/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre4/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -393,15 +399,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre4/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre4/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre4/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre4%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -413,16 +421,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre5/slc7_amd64_gcc820/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre5/slc7_amd64_gcc820/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre5/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre5/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre5/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -439,31 +447,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre5/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre5/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre5/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre5/slc7_amd64_gcc820/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre5/slc7_amd64_gcc820/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre5/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre5/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre5/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre5/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -480,15 +490,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre5/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre5/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre5/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre5%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -500,16 +512,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre6/slc7_amd64_gcc820/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre6/slc7_amd64_gcc820/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre6/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre6/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre6/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -526,28 +538,30 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre6/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre6/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre6/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre6/slc7_amd64_gcc820/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre6/slc7_amd64_gcc820/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre6/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre6/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre6/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -564,15 +578,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre6/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre6/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre6/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre6%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -584,13 +600,13 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre7/slc7_amd64_gcc820/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre7/slc7_amd64_gcc820/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre7/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre7/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -607,31 +623,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre7/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre7/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre7/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre7/slc7_amd64_gcc820/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre7/slc7_amd64_gcc820/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre7/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre7/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre7/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre7/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -648,15 +666,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre7/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre7/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre7/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre7%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -668,16 +688,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre8/slc7_amd64_gcc820/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre8/slc7_amd64_gcc820/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre8/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre8/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre8/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -694,31 +714,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre8/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre8/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre8/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre8/slc7_amd64_gcc820/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre8/slc7_amd64_gcc820/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre8/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre8/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre8/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre8/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -735,15 +757,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre8/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre8/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre8/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre8%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -755,16 +779,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre9/slc7_amd64_gcc820/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre9/slc7_amd64_gcc820/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre9/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre9/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre9/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -781,31 +805,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre9/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre9/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre9/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre9/slc7_amd64_gcc820/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre9/slc7_amd64_gcc820/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre9/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre9/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre9/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre9/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -822,15 +848,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre9/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre9/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre9/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre9%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -842,16 +870,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre10/slc7_amd64_gcc820/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre10/slc7_amd64_gcc820/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre10/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre10/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre10/slc7_amd64_gcc820/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -868,31 +896,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre10/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre10/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre10/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre10/slc7_amd64_gcc820/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre10/slc7_amd64_gcc820/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre10/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre10/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre10/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre10/slc7_amd64_gcc820/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -909,15 +939,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre10/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre10/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre10/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre10%2Fslc7_amd64_gcc820%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -929,16 +961,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre11/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre11/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre11/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre11/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre11/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -955,31 +987,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre11/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre11/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre11/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0_pre11/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre11/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre11/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre11/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0_pre11/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0_pre11/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -996,15 +1030,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre11/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre11/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0_pre11/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0_pre11%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1016,16 +1052,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1042,31 +1078,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_0/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_0/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_0/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1083,15 +1121,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_0/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_0%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1103,16 +1143,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_1/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_1/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_1/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_1/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_1/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1129,31 +1169,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_1/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_1/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_1/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_2_1/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_1/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_1/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_1/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_2_1/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_2_1/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1170,15 +1212,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_1/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_1/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_2_1/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_2_1%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1208,16 +1252,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre1/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre1/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre1/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre1/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre1/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1234,31 +1278,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre1/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre1/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre1/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre1/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre1/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre1/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre1/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre1/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre1/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1275,15 +1321,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre1/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre1/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre1/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1295,16 +1343,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre2/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre2/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre2/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre2/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre2/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1321,31 +1369,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre2/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre2/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre2/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre2/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre2/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre2/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre2/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre2/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre2/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1362,15 +1412,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre2/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre2/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre2/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1382,16 +1434,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre3/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre3/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre3/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre3/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre3/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1408,31 +1460,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre3/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre3/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre3/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre3/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre3/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre3/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre3/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre3/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre3/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1449,15 +1503,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre3/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre3/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre3/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1469,16 +1525,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre4/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre4/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre4/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre4/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre4/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1495,31 +1551,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre4/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre4/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre4/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre4/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre4/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre4/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre4/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre4/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre4/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1536,15 +1594,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre4/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre4/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre4/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre4%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1556,16 +1616,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Circle (Pie chart):
@@ -1576,16 +1636,16 @@
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Circle (Pie chart):
@@ -1601,16 +1661,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1627,31 +1687,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre5/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre5/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre5/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre5/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre5/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1668,15 +1730,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre5/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre5/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre5/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1688,16 +1752,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1714,31 +1778,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1755,15 +1821,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/11834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/11834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/11834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/11834.21/step4/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1775,16 +1843,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1801,31 +1869,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0_pre6/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0_pre6/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1842,15 +1912,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0_pre6/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0_pre6%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -1862,16 +1934,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1888,31 +1960,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1939,16 +2013,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -1965,31 +2039,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_11_3_0/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_11_3_0%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_11_3_0/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_11_3_0/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_11_3_0/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2043,16 +2119,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2069,31 +2145,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre1/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre1/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre1/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre1/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2120,16 +2198,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2146,31 +2224,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre1/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre1/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre1/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre1%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre1/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre1/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2197,16 +2277,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2223,31 +2303,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2264,15 +2346,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/11834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/11834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/11834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/11834.21/step4/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2284,16 +2368,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2310,31 +2394,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre2/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre2/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2351,15 +2437,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre2/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre2%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2371,16 +2459,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2397,31 +2485,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2438,15 +2528,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/11834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/11834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/11834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/11834.21/step4/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2458,16 +2550,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2484,31 +2576,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre3/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre3/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2525,15 +2619,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre3/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre3%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2609,60 +2705,64 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/11834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/11834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/11834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/11834.21/step4/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2674,16 +2774,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/23434.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/23434.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/23434.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2700,31 +2800,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/23434.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/23434.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/23434.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/23434.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/23434.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/23434.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/23434.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2741,15 +2843,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/23434.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/23434.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre5/23434.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre5%2Fslc7_amd64_gcc900%2F23434.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2761,16 +2865,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/34834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/34834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2792,16 +2896,16 @@
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/34834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/34834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre5/34834.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre5/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2828,16 +2932,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2854,31 +2958,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2895,15 +3001,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/11834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/11834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/11834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/11834.21/step4/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -2915,16 +3023,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/34834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/34834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2941,31 +3049,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/34834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/34834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/34834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/34834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/34834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0_pre6/34834.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0_pre6/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -2982,15 +3092,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/34834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/34834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0_pre6/34834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0_pre6%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3002,16 +3114,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3028,31 +3140,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3069,15 +3183,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/11834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/11834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/11834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/11834.21/step4/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3089,16 +3205,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0/slc7_amd64_gcc900/34834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/34834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3115,31 +3231,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/34834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/34834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/34834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_0_0/slc7_amd64_gcc900/34834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/34834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_0_0/34834.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_0_0/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3156,15 +3274,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/34834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/34834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_0_0/34834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_0_0%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3194,16 +3314,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3220,31 +3340,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3261,15 +3383,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/11834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/11834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/11834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/11834.21/step4/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3281,16 +3405,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/34834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/34834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3307,31 +3431,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/34834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/34834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/34834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/34834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/34834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre1/34834.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre1/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3348,15 +3474,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/34834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/34834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre1/34834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre1%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3368,16 +3496,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3394,31 +3522,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3435,15 +3565,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/11834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/11834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/11834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/11834.21/step4/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3455,16 +3587,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/34834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/34834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3481,31 +3613,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/34834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/34834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/34834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/34834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/34834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre2/34834.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre2/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3522,15 +3656,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/34834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/34834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre2/34834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre2%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3542,16 +3678,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/11834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/11834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step3//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step3//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step3//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step3//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/11834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3568,31 +3704,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/11834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/11834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/11834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/11834.21/step3/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/11834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/11834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step4//mem_live.200" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step4//mem_live.200" title="MEM time check">[MEM Profiler igprof.200]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step4//mem_live.399" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/11834.21/step4//mem_live.399" title="MEM time check">[MEM Profiler igprof.399]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/11834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3609,15 +3747,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/11834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/11834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/11834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/11834.21/step4/mem_live.399.html" title="MEM compare">[MEM ig399 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F11834.21%2Fmem_live.399.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>
@@ -3629,16 +3769,16 @@
 			<li><strong>step3_AOD(RECO):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/34834.21/step3.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step3//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/34834.21/step3_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step3//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step3//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step3//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step3//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step3//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step3//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/34834.21/step3_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3655,31 +3795,33 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/34834.21/step3/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/34834.21/step3/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/34834.21/step3/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F34834.21%2Fstep3_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 
 			<li><strong>step4_MiniAOD(PAT):</strong>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/Time_Mem_Summary/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/34834.21/step4.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>
 			
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step4//cpu_endjob" title="CPU time check">[CPU Profiler igprof.]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/34834.21/step4_cpu.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step4//mem_live.1" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step4//mem_live.1" title="MEM time check">[MEM Profiler igprof.1]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step4//mem_live.50" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step4//mem_live.50" title="MEM time check">[MEM Profiler igprof.50]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step4//mem_live.99" title="CPU time check">[CPU Profiler igprof]</a>
+				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_1_0_pre3/34834.21/step4//mem_live.99" title="MEM time check">[MEM Profiler igprof.99]</a>
 				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/RES/CMSSW_12_1_0_pre3/slc7_amd64_gcc900/34834.21/step4_mem.res" title="txtLink">[txtLink]</a>
 				<ul>
 			<li>Comparison:
@@ -3696,15 +3838,17 @@
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/34834.21/step4/cpu_endjob.html" title="CPU compare">[CPU compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/34834.21/step4/mem_live.1.html" title="MEM compare">[MEM ig1 compare]</a>
 			</li>
+			
 			<li>
 			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/comp_igprof/html/CMSSW_12_1_0_pre3/34834.21/step4/mem_live.99.html" title="MEM compare">[MEM ig99 compare]</a>
 			</li>
-	
+			
 			<li>Circle (Pie chart):
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F34834.21%2Fstep4_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
+			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?local=false&dataset=CMSSW_12_1_0_pre3%2Fslc7_amd64_gcc900%2F34834.21%2Fmem_live.99.html_circles&resource=time_real&colours=default&groups=package&threshold=0" title="Circle">[Circle]</a>
 			</li>
 		</ul>
 </ul>


### PR DESCRIPTION
- The link title, which is written `CPU profiler`, was changed to correct title.

- The `getTimeMemorySummary` about CMSSW_12_1_0_pre3 was generated and linked.

- I used softcoding for `MEM igx compare` and `MEM ig399 compare` was generated correctly in framework 11834.21 